### PR TITLE
Feature: Copy/open a specific commit in the browser. (fix #1)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn get_remote_parts(url: &str) -> Result<(&str, &str)> {
 
 const BROWSER: &str = "BROWSER";
 const DEFAULT_REMOTE_ORIGIN: &str = "origin";
+const BITBUCKET_HOSTNAME: &str = "bitbucket.org";
 
 /// Enumeration to store exit codes. The first one, Success is by default set to 0
 enum ExitCode {
@@ -94,12 +95,23 @@ fn main() {
 
     let parts = get_remote_parts(remote_url).unwrap();
 
-    let url = format!(
-        "https://{domain}/{repository}/tree/{branch}",
-        domain = parts.0,
-        repository = parts.1,
-        branch = branch
-    );
+    let url = if let Some(commit) = opt.commit {
+        format!(
+            "https://{domain}/{repository}/{path}/{commit}",
+            domain = parts.0,
+            path = if parts.0 == BITBUCKET_HOSTNAME {"commits"} else {"commit"},
+            repository = parts.1,
+            commit = commit
+        )
+    } else {
+        format!(
+            "https://{domain}/{repository}/{path}/{branch}",
+            domain = parts.0,
+            path = if parts.0 == BITBUCKET_HOSTNAME {"src"} else {"tree"},
+            repository = parts.1,
+            branch = branch
+        )
+    };
 
     // If the option is available through the command line, open the given one
     match opt.browser {

--- a/src/options.rs
+++ b/src/options.rs
@@ -14,6 +14,13 @@ pub struct Opt {
     #[structopt(short, long)]
     pub branch: Option<String>,
 
+    /// Set a commit
+    ///
+    /// By setting a commit, you can override the default behavior that will
+    /// set the branch to the current one in the repository.
+    #[structopt(short, long)]
+    pub commit: Option<String>,
+
     /// Set the browser
     ///
     /// If you set the browser option, it will override the other configuration.


### PR DESCRIPTION
Support copy a commit link with:
```
gitweb --commit 0b6e00b6 -B ""
```