### PR TITLE
Add instructions for installation using macports

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ cargo install gitweb
 
 Download the binary from the [latest release](https://github.com/yoannfleurydev/gitweb/releases/latest) and put it in your PATH.
 
+### 🖥 The MacPorts way
+
+```
+sudo port selfupdate
+sudo port install gitweb
+```
+
 ## Usage
 
 `gitweb` will by default open the remote in the browser of the current


### PR DESCRIPTION
I'm a macOS user and noticed that gitweb is unavailable on [macports](https://www.macports.org/), so I took the liberty of adding it. Hope you don't mind!

Port details: https://ports.macports.org/port/gitweb/summary
Port definition: https://github.com/macports/macports-ports/blob/master/devel/gitweb/Portfile
